### PR TITLE
Add 'execute' and 'log' methods

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,3 @@
 language: crystal
+crystal:
+  - latest

--- a/Cakefile.sample
+++ b/Cakefile.sample
@@ -19,3 +19,23 @@ end
 task :second do
   # yay we are here!
 end
+
+# to execute shell commands
+task :build do
+  execute "shards build"
+
+  # or with sweet logs
+  execute(
+    cmd: "shards build",
+    announce: "Building binary...",
+    success: "Binary built!",
+    error: "Build failed."
+  )
+end
+
+# to log things
+task :deploy do
+  # your deploy code
+  log "Deploy successful!"
+  log "Or errored.", 1
+end

--- a/README.md
+++ b/README.md
@@ -89,3 +89,4 @@ end
 ## Contributors
 
 - [[axvm]](https://github.com/axvm) Alexander Marchenko - creator, maintainer
+- [[triinoxys]](https://github.com/triinoxys) Alexandre Guiot--Valentin - contributor

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Cake
+# Cake [![Build Status](https://travis-ci.org/axvm/cake.svg?branch=master)](https://travis-ci.org/axvm/cake)
 
 Cake is a powerful and flexible Make-like utility tool.
 Implement tasks on plain crystal-lang and Make Tasks Great Again!
@@ -73,7 +73,10 @@ end
 
 ## Development
 
-TODO: Write development instructions here
+1. Implement feature and tests
+2. Create pull request
+3. ...
+4. Profit!
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,26 @@ end
 task :second do
   # yay we are here!
 end
+
+# Execute shell commands
+task :build do
+  execute "shards build"
+
+  # or with sweet logs
+  execute(
+    cmd: "shards build",
+    announce: "Building binary...",
+    success: "Binary built!",
+    error: "Build failed."
+  )
+end
+
+# Log things
+task :deploy do
+  # your deploy code
+  log "Deploy successful!"
+  log "Or errored.", 1
+end
 ```
 
 ## Development

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: cake
-version: 1.0.3
+version: 1.1.0
 
 authors:
   - Alexander Marchenko <axvmindaweb@gmail.com>

--- a/spec/cake_spec.cr
+++ b/spec/cake_spec.cr
@@ -7,6 +7,6 @@ end
 
 describe Cake do
   it "has DSL methods" do
-    responds_to_methods [ :task, :invoke! ]
+    responds_to_methods [ :desc, :task, :invoke!, :execute, :log ]
   end
 end

--- a/spec/dsl_spec.cr
+++ b/spec/dsl_spec.cr
@@ -24,4 +24,20 @@ describe Cake::DSL do
   it "should accept symbols in task" do
     Cake::DSL.task :test do; end
   end
+
+  it "should accept string in log" do
+    puts ""
+    Cake::DSL.log "test"
+  end
+
+  it "should print errored log when needed" do
+    puts ""
+    Cake::DSL.log "test", 1
+  end
+
+  it "should execute commands" do
+    Cake::DSL.execute("touch test.file.tmp")
+    File.read("test.file.tmp").should eq ""
+    Cake::DSL.execute("rm test.file.tmp")
+  end
 end

--- a/src/cake/dsl.cr
+++ b/src/cake/dsl.cr
@@ -27,7 +27,11 @@ module Cake::DSL
   end
 
   def log(message : String, status = 0)
-    puts "#{">> ".colorize(status == 0 ? :light_cyan : :light_red)} #{message}"
+    if status == 0
+      STDOUT.puts "#{">> ".colorize(:light_cyan)} #{message}"
+    else
+      STDERR.puts "#{">> ".colorize(:light_red)} #{message}"
+    end
   end
 
   def execute(cmd : String, args = [] of String, announce = "", success = "", error = "", output = "always")

--- a/src/cake/dsl.cr
+++ b/src/cake/dsl.cr
@@ -41,6 +41,10 @@ module Cake::DSL
     status = Process.run(command: cmd, args: args, output: io, error: io)
 
     unless io.empty? || io.to_s == "" || io.to_s == "\n"
+      if io.to_s.ends_with? "\n"
+        io = IO::Memory.new io.to_s.chomp
+      end
+
       case output
       when "never"
         nil


### PR DESCRIPTION
These methods can be used in the Cakefile, allowing user to execute shell commands and logging output/status with a nice format.

__log__:
```cr
log "Success!"
status = 1
log "Error!", status
```
A status of 0 (default) will print a success log, others status will print an error log.


__execute__:
```cr
execute "shards build"

# or with logs
execute(
  cmd: "shards build",
  announce: "Building binary...",
  success: "Binary built!",
  error: "Build failed."
)

# command's output can also be controlled with the 'output' parameter
execute(
  cmd: "crystal spec",
  announce: "Running specs...",
  success: "All specs passed successfully!",
  error: "Specs failed.",
  output: "error"
)
# like this, Specs output will only show if it returned errors
# ('output' can be "always", "never", "success" or "error")
```

**Here is a demo!**
[![asciicast](https://img.triinoxys.fr/cake-pr6-demo.png)](https://asciinema.org/a/193756)

Here, I log all the commands and I print Spec's output only if it failed.
This allows a clean rendering, not ruined by the useless output of successful Specs.

**Make Tasks Great Again!**