### PR TITLE
Use __DIR__ instead of a fixed path

### DIFF
--- a/src/cake/templates/run_task.cr
+++ b/src/cake/templates/run_task.cr
@@ -4,5 +4,5 @@ class Cake::Templates::RunTask
   def initialize(@src_path : String, @task_name : String, @import_segment : Array(String), @code_segment : Array(String))
   end
 
-  ECR.def_to_s "src/cake/templates/run_task.ecr"
+  ECR.def_to_s "#{__DIR__}/run_task.ecr"
 end

--- a/src/cake/templates/task_list.cr
+++ b/src/cake/templates/task_list.cr
@@ -4,5 +4,5 @@ class Cake::Templates::TaskList
   def initialize(@src_path : String, @import_segment : Array(String), @code_segment : Array(String))
   end
 
-  ECR.def_to_s "src/cake/templates/task_list.ecr"
+  ECR.def_to_s "#{__DIR__}/task_list.ecr"
 end


### PR DESCRIPTION
This allows it to build properly if defined as a dependency, as it'd be built via `lib/cake/src/cli.cr` from the root of a project.